### PR TITLE
Fixed program not reading defines.json as expected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.gradle
 /.idea
 /build
+/bin

--- a/src/main/java/com/ddf/materialbintool/main/Main.java
+++ b/src/main/java/com/ddf/materialbintool/main/Main.java
@@ -149,12 +149,13 @@ public class Main {
 
 						for (FlagMode flagMode : variant.flagModeList) {
 							if (flagModesDefines != null && flagModesDefines.has(flagMode.getKey())) {
-								for (JsonElement element : flagModesDefines.getAsJsonArray(flagMode.getKey())) {
-									defines.addDefine(element.getAsString());
+								JsonObject flag = flagModesDefines.getAsJsonObject(flagMode.getKey());
+								if (flag.has(flagMode.getValue())) {
+									for (JsonElement element : flag.getAsJsonArray(flagMode.getValue())) {
+										defines.addDefine(element.getAsString());
+									}
 								}
-								continue;
-							}
-							if ("On".equals(flagMode.getValue())) {
+							} else if ("On".equals(flagMode.getValue())) {
 								defines.addDefine(StringUtil.toUnderScore(flagMode.getKey()));
 							}
 						}


### PR DESCRIPTION
According to the README file, the following would be added to `defines.json`.
``` json
"flagModes": {
    "SourceInputType0": {
        "Constant": [],
        "Sampled": ["SOURCE_INPUT_0_SAMPLED"]
    },
    "SourceInputType1": {
        "Constant": [],
        "Sampled": ["SOURCE_INPUT_1_SAMPLED"]
    },
    "SourceInputType2": {
        "Constant": [],
        "Sampled": ["SOURCE_INPUT_2_SAMPLED"]
    }
}
```
However, the program does not properly read it. Instead, it would read something like this.
``` json
"flagModes": {
    "SourceInputType0": ["SOURCE_INPUT_0_SAMPLED"],
    "SourceInputType1": ["SOURCE_INPUT_1_SAMPLED"],
    "SourceInputType2": ["SOURCE_INPUT_2_SAMPLED"]
}
```
This pull request fixes that.